### PR TITLE
adding proper chat-jail

### DIFF
--- a/common.lua
+++ b/common.lua
@@ -1,8 +1,14 @@
 
 beerchat.has_player_muted_player = function(name, other_name)
+	-- ignore muting for jailed users
+	if beerchat.is_player_jailed(name) then
+		return false
+	end
 	local player = minetest.get_player_by_name(name)
 	-- check jic method is used incorrectly
-	if not player then return true end
+	if not player then
+		return true
+	end
 
 	local key = "beerchat:muted:" .. other_name
 	local meta = player:get_meta()
@@ -15,7 +21,15 @@ beerchat.is_player_subscribed_to_channel = function(name, channel)
 end -- is_player_subscribed_to_channel
 
 beerchat.send_message = function(name, message, channel)
+	local jailed = beerchat.is_player_jailed(name)
+	local is_jail_channel = channel == beerchat.jail_channel_name
+	if jailed and not is_jail_channel then
+		return
+	end
 	minetest.chat_send_player(name, message)
+	if is_jail_channel then
+		return
+	end
 -- TODO: read player settings for channel sounds
 	if beerchat.enable_sounds and channel ~= beerchat.main_channel_name then
 		minetest.sound_play(beerchat.channel_message_sound, { to_player = name, gain = beerchat.sounds_default_gain } )

--- a/hash.lua
+++ b/hash.lua
@@ -13,6 +13,9 @@ minetest.register_on_chat_message(function(name, message)
 	end
 
 	if channel_name and msg then
+		if beerchat.is_player_jailed(name) then
+			return false
+		end
 		if not beerchat.channels[channel_name] then
 			minetest.chat_send_player(name, "Channel "..channel_name.." does not exist. Make sure the channel still "..
 											"exists and you format its name properly, e.g. #channel message or #my channel: message")
@@ -36,6 +39,9 @@ minetest.register_on_chat_message(function(name, message)
 	else
 		channel_name = string.match(message, "^#(.*)")
 		if channel_name then
+			if beerchat.is_player_jailed(name) then
+				return false
+			end
 			if not beerchat.channels[channel_name] then
 				minetest.chat_send_player(name, "Channel "..channel_name.." does not exist")
 			elseif not beerchat.is_player_subscribed_to_channel(name, channel_name) then

--- a/init.lua
+++ b/init.lua
@@ -7,7 +7,10 @@ local http = minetest.request_http_api()
 
 beerchat = {
 	-- The main channel is the one you send messages to when no channel is specified
-	main_channel_name = "main",
+	main_channel_name = minetest.settings:get("beerchat.main_channel_name"),
+
+	-- Jail channel is where you put annoying missbehaving users with /force2channel
+	jail_channel_name = minetest.settings:get("beerchat.jail_channel_name"),
 
 	-- The default color of channels when no color is specified
 	default_channel_color = "#ffffff",
@@ -38,7 +41,12 @@ beerchat = {
 
 }
 
+if nil == beerchat.main_channel_name or "" == beerchat.main_channel_name then
+	beerchat.main_channel_name = "main"
+end
+
 local MP = minetest.get_modpath("beerchat")
+dofile(MP.."/jail.lua")
 dofile(MP.."/common.lua")
 dofile(MP.."/format_message.lua")
 dofile(MP.."/hooks.lua")

--- a/jail.lua
+++ b/jail.lua
@@ -1,0 +1,9 @@
+beerchat.jail_list = {}
+
+if nil == beerchat.jail_channel_name or "" == beerchat.jail_channel_name then
+	beerchat.jail_channel_name = "wail"
+end
+
+beerchat.is_player_jailed = function(name)
+	return true == beerchat.jail_list[name]
+end

--- a/me.lua
+++ b/me.lua
@@ -6,6 +6,9 @@ local me_override = {
 	description = "Send message in the \"* player message\" format, e.g. /me eats pizza becomes |#"..
 		beerchat.main_channel_name.."| * Player01 eats pizza",
 	func = function(name, param)
+		if beerchat.is_player_jailed(name) then
+			return false, "You are in chat-jail, you may not use /me command."
+		end
 		local msg = param
 		local channel_name = beerchat.main_channel_name
 		if not beerchat.channels[channel_name] then

--- a/pm.lua
+++ b/pm.lua
@@ -12,6 +12,9 @@ minetest.register_on_chat_message(function(name, message)
 	minetest.log("action", "CHAT " .. name .. ": " .. message)
 	local players, msg = string.match(message, "^@([^%s:]*)[%s:](.*)")
 	if players and msg then
+		if beerchat.is_player_jailed(name) then
+			return false
+		end
 		if msg == "" then
 			minetest.chat_send_player(name, "Please enter the private message you would like to send")
 		else
@@ -68,6 +71,9 @@ minetest.register_on_chat_message(function(name, message)
 				-- Register the chat in the target persons last spoken to table
 				atchat_lastrecv[name] = players
 				if atleastonesent then
+					if beerchat.is_player_jailed(name) then
+						return false
+					end
 					successplayers = successplayers:sub(1, -2)
 					if (successplayers ~= name) then
 						minetest.chat_send_player(
@@ -153,6 +159,9 @@ local msg_override = {
 				"for compatibility with the old chat command but with new style chat muting support "..
 				  "(players will not receive your message if they muted you) and multiple (comma separated) player support",
 	func = function(name, param)
+		if beerchat.is_player_jailed(name) then
+			return false, "You are in chat-jail, no PMs for you."
+		end
 		minetest.log("action", "PM " .. name .. ": " .. param)
 		local players, msg = string.match(param, "^(.-) (.*)")
 		if players and msg then

--- a/session.lua
+++ b/session.lua
@@ -21,6 +21,15 @@ minetest.register_on_joinplayer(function(player)
 		beerchat.currentPlayerChannel[name] = beerchat.main_channel_name
 	end
 
+	local jailed = 1 == meta:get_int("beerchat:jailed")
+	if jailed then
+		beerchat.jail_list[name] = true
+		beerchat.currentPlayerChannel[name] = beerchat.jail_channel_name
+		beerchat.playersChannels[name][beerchat.jail_channel_name] = "joined"
+	else
+		beerchat.jail_list[name] = nil
+	end
+
 end)
 
 minetest.register_on_leaveplayer(function(player)
@@ -28,5 +37,6 @@ minetest.register_on_leaveplayer(function(player)
 	beerchat.playersChannels[name] = nil
 	atchat_lastrecv[name] = nil
 	beerchat.currentPlayerChannel[name] = nil
+	beerchat.jail_list[name] = nil
 end)
 

--- a/storage.lua
+++ b/storage.lua
@@ -5,8 +5,23 @@ local main_channel_color = "#ffffff"		-- The color in hex of the main channel
 
 if beerchat.mod_storage:get_string("channels") == "" then
 	minetest.log("action", "[beerchat] One off initializing mod storage")
-	beerchat.channels[beerchat.main_channel_name] = { owner = main_channel_owner, color = main_channel_color }
+	beerchat.channels[beerchat.main_channel_name] = {
+		owner = main_channel_owner,
+		color = main_channel_color
+	}
+	beerchat.channels[beerchat.jail_channel_name] = {
+		owner = main_channel_owner,
+		color = main_channel_color
+	}
 	beerchat.mod_storage:set_string("channels", minetest.write_json(beerchat.channels))
 end
 
 beerchat.channels = minetest.parse_json(beerchat.mod_storage:get_string("channels"))
+beerchat.channels[beerchat.main_channel_name] = {
+	owner = main_channel_owner,
+	color = main_channel_color
+}
+beerchat.channels[beerchat.jail_channel_name] = {
+	owner = main_channel_owner,
+	color = main_channel_color
+}

--- a/whisper.lua
+++ b/whisper.lua
@@ -12,6 +12,9 @@ beerchat.whisper = function(name, message)
 	if dollar ~= "$" then
 		return false
 	end
+	if beerchat.is_player_jailed(name) then
+		return false
+	end
 	local radius = tonumber(sradius)
 	if not radius then
 		radius = whisper_default_range


### PR DESCRIPTION
This proposal adds a jail channel.
use /force2channel to put user in jail.
Once in jail
- /mutes are ignored for the jailed user.
- user can't leave channels
- can't switch channels
- can't PM or whisper
- can't read any other channels
- must deal with what is being said or leave the server
- messages do not make a sound

Other users can join the jail channel (by default #wail) and reason with jailies.

Main and jail channel can be set in minetest.conf

I have not looked into what happens with irc/discord, assuming nothing happens if not set up to listen to jail channel anyway.
 
Please test thoroughly before merging (if at all) as this is an important mod.
It has worked well enough on my tests, but I may have missed some special cases.

@thomasrudin @S-S-X @coil0 @6r1d @OgelGames did I forget someone?