### PR TITLE
Cleanup control characters from messages

### DIFF
--- a/cleaner.lua
+++ b/cleaner.lua
@@ -1,0 +1,4 @@
+
+beerchat.register_callback('on_receive', function(msg_data)
+	msg_data.message = msg_data.message:gsub('%c','')
+end)

--- a/hash.lua
+++ b/hash.lua
@@ -4,6 +4,13 @@
 hashchat_lastrecv = {}
 
 minetest.register_on_chat_message(function(name, message)
+	local msg_data = {name=name,message=message}
+	if beerchat.execute_callbacks('on_receive', msg_data) then
+		message = msg_data.message
+	else
+		return false
+	end
+
 	local channel_name, msg = string.match(message, "^#(.-): (.*)")
 	if not beerchat.channels[channel_name] then
 		channel_name, msg = string.match(message, "^#(.-) (.*)")

--- a/hooks.lua
+++ b/hooks.lua
@@ -13,6 +13,9 @@ beerchat.cb.before_mute 		= {} -- executed before player is muted
 beerchat.cb.before_check_muted 	= {} -- executed before has_player_muted_player checks
 beerchat.cb.on_forced_join 		= {} -- executed right after player is forced to channel
 
+-- Callbacks that can edit message contents
+beerchat.cb.on_receive 			= {} -- executed when new message is received
+
 beerchat.register_callback = function(trigger, fn)
 	if type(fn) ~= 'function' then
 		print('Error: Invalid fn argument for beerchat.register_callback, must be function. Got ' .. type(fn))

--- a/init.lua
+++ b/init.lua
@@ -79,6 +79,10 @@ if minetest.settings:get_bool("beerchat.enable_jail") then
 	dofile(MP.."/jail.lua")
 end
 
+if minetest.settings:get_bool("beerchat.enable_cleaner") then
+	dofile(MP.."/cleaner.lua")
+end
+
 if minetest.settings:get_bool("enable_beerchat_integration_test") then
   dofile(MP.."/integration_test.lua")
 end

--- a/message.lua
+++ b/message.lua
@@ -40,6 +40,14 @@ end
 
 
 minetest.register_on_chat_message(function(name, message)
+
+	local msg_data = {name=name,message=message}
+	if beerchat.execute_callbacks('on_receive', msg_data) then
+		message = msg_data.message
+	else
+		return false
+	end
+
 	local channel_name = beerchat.currentPlayerChannel[name]
 
 	if not minetest.check_player_privs(name, "shout") then

--- a/pm.lua
+++ b/pm.lua
@@ -10,6 +10,14 @@ atchat_lastrecv = {}
 
 minetest.register_on_chat_message(function(name, message)
 	minetest.log("action", "CHAT " .. name .. ": " .. message)
+
+	local msg_data = {name=name,message=message}
+	if beerchat.execute_callbacks('on_receive', msg_data) then
+		message = msg_data.message
+	else
+		return false
+	end
+
 	local players, msg = string.match(message, "^@([^%s:]*)[%s:](.*)")
 	if players and msg then
 		if msg == "" then

--- a/whisper.lua
+++ b/whisper.lua
@@ -8,6 +8,14 @@ local whisper_string = "|#${channel_name}| <${from_player}> whispers: ${message}
 -- $ chat a.k.a. dollar chat code, to whisper messages in chat to nearby players only using $,
 -- optionally supplying a radius e.g. $32 Hello
 beerchat.whisper = function(name, message)
+
+	local msg_data = {name=name,message=message}
+	if beerchat.execute_callbacks('on_receive', msg_data) then
+		message = msg_data.message
+	else
+		return false
+	end
+
 	local dollar, sradius, msg = string.match(message, "^($)(.-) (.*)")
 	if dollar ~= "$" then
 		return false


### PR DESCRIPTION
https://github.com/pandorabox-io/pandorabox.io/issues/532

To enable cleanup add `beerchat.enable_cleaner = true` to minetest.conf

Removes all control characters from all incoming messages.