### PR TITLE
Allow colorizing chat messages on selected channels

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -92,6 +92,7 @@ if minetest.settings:get_bool("enable_beerchat_integration_test") then
   dofile(MP.."/integration_test.lua")
 end
 
+dofile(MP.."/plugin/colorize.lua")
 
 print("[OK] beerchat")
 

--- a/message.lua
+++ b/message.lua
@@ -38,8 +38,10 @@ beerchat.send_on_channel = function(name, channel_name, message)
 end
 
 beerchat.register_callback("on_send_on_channel", function(msg, target)
-	return beerchat.is_player_subscribed_to_channel(target, msg.channel)
-		and not beerchat.has_player_muted_player(target, msg.name)
+	if not beerchat.is_player_subscribed_to_channel(target, msg.channel)
+		or beerchat.has_player_muted_player(target, msg.name) then
+		return false
+	end
 end)
 
 minetest.register_on_chat_message(function(name, message)

--- a/plugin/colorize.lua
+++ b/plugin/colorize.lua
@@ -1,0 +1,20 @@
+
+local colorize_channels = minetest.settings:get("beerchat.colorize_channels")
+
+if colorize_channels then
+
+	local channels = string.gmatch(colorize_channels, "[^%s,]+")
+	local allowed_channels = {}
+	for channel in channels do
+		allowed_channels[channel] = true
+	end
+
+	if next(allowed_channels) then
+		beerchat.register_callback('on_send_on_channel', function(msg_data)
+			if msg_data.channel and allowed_channels[msg_data.channel] then
+				msg_data.message = msg_data.message:gsub('%((%#%x%x%x)%)', string.char(0x1B) .. '(c@%1)')
+			end
+		end)
+	end
+
+end


### PR DESCRIPTION
Also fix `on_send_on_channel` callbacks through `message.lua`, was canceling all upcoming callbacks on success.

To allow sending `(#f00)Hello red world! (#0f0)And green too!` on channel there's configuration option to enable colorize on channels:
```
beerchat.colorize_channels = fun, pvp
```
Accepts comma or space separated list of channels.