### PR TITLE
Improve http bridge message cleanup

### DIFF
--- a/plugin/cleaner.lua
+++ b/plugin/cleaner.lua
@@ -5,5 +5,14 @@ end)
 
 beerchat.register_callback('on_http_receive', function(msg_data)
 	-- Trim spaces and newlines, add ">" to mark newlines in incoming message
-	msg_data.message = msg_data.message:gsub('%s+$',''):gsub('(%s)%s+','%1'):gsub('[\r\n]','\n  > ')
+	local msg = msg_data.message
+		:gsub('%s+$','') -- Remove trailing space
+		:gsub('<:[%w_]+:%d+>','') -- Remove long emoji codes
+		:gsub('(%s)%s+','%1') -- Trim all whitespace
+		:gsub('[\r\n]','\n  > ') -- Add line continuation markers
+	if not msg:find("[^%c%p%s]") then
+		-- Throw away messages that do not contain any words after cleanup
+		return false
+	end
+	msg_data.message = msg
 end)


### PR DESCRIPTION
Remove long emoji codes matching something like `<:ab_cd:1234>`.
Drop messages containing only spaces, control characters and punctuation (after cleanup).