### PR TITLE
Cleanup / refactoring, small fixes, join hook

### DIFF
--- a/chatcommands.lua
+++ b/chatcommands.lua
@@ -396,80 +396,6 @@ local list_muted = {
 	end
 }
 
-beerchat.force_player_to_channel = function(name, param)
-	if not param or param == "" then
-		return false, "ERROR: Invalid number of arguments. Please supply the "
-			.. "channel name and the player name."
-	end
-
-	local channel_name, player_name = string.match(param, "(.*), ?(.*)")
-
-	if not channel_name or channel_name == "" then
-		return false, "ERROR: Channel name is empty."
-	end
-
-	if not player_name or player_name == "" then
-		return false, "ERROR: Player name not supplied or empty."
-	end
-
-	if not beerchat.channels[channel_name] then
-		return false, "ERROR: Channel " .. channel_name .. " does not exist."
-	end
-
-	local player = minetest.get_player_by_name(player_name)
-	if not player then
-		return false, "ERROR: " .. player_name .. " does not exist or is not online."
-	else
-		local meta = player:get_meta()
-		-- force join
-		beerchat.playersChannels[player_name] = beerchat.playersChannels[player_name] or {}
-		beerchat.playersChannels[player_name][channel_name] = "joined"
-		meta:set_string(
-			"beerchat:channels",
-			minetest.write_json(beerchat.playersChannels[player_name])
-		)
-		-- force default channel
-		beerchat.currentPlayerChannel[player_name] = channel_name
-		meta:set_string("beerchat:current_channel", channel_name)
-
-		if not beerchat.execute_callbacks('on_forced_join', name, player_name, channel_name, meta) then
-			return false
-		end
-
-		-- inform user
-		minetest.chat_send_player(player_name, name .. " has set your default channel to "
-			.. channel_name .. ".")
-		-- feedback to mover
-		minetest.chat_send_player(name, "Set default channel of " .. player_name
-			.. " to " .. channel_name .. ".")
-		-- inform moderators, if moderator channel is set
-		if beerchat.moderator_channel_name then
-			beerchat.send_on_channel(beerchat.channels[beerchat.main_channel_name].owner,
-				beerchat.moderator_channel_name,
-				name .. " has set default channel of " .. player_name .. " to "
-				.. channel_name .. ".")
-		end
-		-- inform admin
-		minetest.log("action", "CHAT " .. name .. " moved " .. player_name
-			.. " to channel " .. channel_name)
-	end
-	return true
-end
-
-local force_player_to_channel = {
-	params = "<Channel Name>, <Player Name>",
-	description = "Force player named <Player Name> to channel named <Channel Name>. "
-		.. "You must have ban priv to use this.",
-	privs = { ban = true },
-	func = beerchat.force_player_to_channel
-}
-
-local whisper = {
-	params = "<message>",
-	description = "Whisper command for those who can't use $",
-	func = function(name, param) beerchat.whisper(name, "$ " .. param) end
-}
-
 minetest.register_chatcommand("cc", create_channel)
 minetest.register_chatcommand("create_channel", create_channel)
 minetest.register_chatcommand("dc", delete_channel)
@@ -490,8 +416,3 @@ minetest.register_chatcommand("ignore", mute_player)
 minetest.register_chatcommand("unmute", unmute_player)
 minetest.register_chatcommand("unignore", unmute_player)
 minetest.register_chatcommand("list_muted", list_muted)
-
-minetest.register_chatcommand("force2channel", force_player_to_channel)
-
-minetest.register_chatcommand("whis", whisper)
-

--- a/hooks.lua
+++ b/hooks.lua
@@ -13,6 +13,9 @@ beerchat.cb.before_mute 		= {} -- executed before player is muted
 beerchat.cb.before_check_muted 	= {} -- executed before has_player_muted_player checks
 beerchat.cb.on_forced_join 		= {} -- executed right after player is forced to channel
 
+-- Special events
+beerchat.cb.after_joinplayer	= {} -- executed after player has joined and configurations loaded
+
 -- Callbacks that can edit message contents
 beerchat.cb.on_receive 			= {} -- executed when new message is received
 beerchat.cb.on_http_receive 		= {} -- executed when new message is received through http polling

--- a/plugin/colorize.lua
+++ b/plugin/colorize.lua
@@ -1,7 +1,28 @@
 
+--
+-- Allow using colors on chat messages by sending "(#f00)Red (#0f0)Green (#00f)Blue"
+--
+-- Configuration to allow on selected chat channels:
+--   beerchat.colorize_channels = channel1, channel2, channel3
+-- Configuration to allow on all chat channels:
+--   beerchat.colorize_channels = *
+-- Configuration to allow only on channel named * (not sure why...):
+--   beerchat.colorize_channels = *,
+--
+
 local colorize_channels = minetest.settings:get("beerchat.colorize_channels")
 
-if colorize_channels then
+if colorize_channels == "*" then
+
+	-- Colorize all chat channels
+
+	beerchat.register_callback('on_send_on_channel', function(msg_data)
+		msg_data.message = msg_data.message:gsub('%((%#%x%x%x)%)', string.char(0x1B) .. '(c@%1)')
+	end)
+
+elseif colorize_channels then
+
+	-- Colorize only specific selected chat channels
 
 	local channels = string.gmatch(colorize_channels, "[^%s,]+")
 	local allowed_channels = {}

--- a/plugin/force2channel.lua
+++ b/plugin/force2channel.lua
@@ -1,0 +1,71 @@
+--
+-- Adds chat command /force2channel <Channel Name>, <Player Name>
+-- Command requires ban privilege.
+--
+
+beerchat.force_player_to_channel = function(name, param)
+	if not param or param == "" then
+		return false, "ERROR: Invalid number of arguments. Please supply the "
+			.. "channel name and the player name."
+	end
+
+	local channel_name, player_name = string.match(param, "(.*), ?(.*)")
+
+	if not channel_name or channel_name == "" then
+		return false, "ERROR: Channel name is empty."
+	end
+
+	if not player_name or player_name == "" then
+		return false, "ERROR: Player name not supplied or empty."
+	end
+
+	if not beerchat.channels[channel_name] then
+		return false, "ERROR: Channel " .. channel_name .. " does not exist."
+	end
+
+	local player = minetest.get_player_by_name(player_name)
+	if not player then
+		return false, "ERROR: " .. player_name .. " does not exist or is not online."
+	else
+		local meta = player:get_meta()
+		-- force join
+		beerchat.playersChannels[player_name] = beerchat.playersChannels[player_name] or {}
+		beerchat.playersChannels[player_name][channel_name] = "joined"
+		meta:set_string(
+			"beerchat:channels",
+			minetest.write_json(beerchat.playersChannels[player_name])
+		)
+		-- force default channel
+		beerchat.currentPlayerChannel[player_name] = channel_name
+		meta:set_string("beerchat:current_channel", channel_name)
+
+		if not beerchat.execute_callbacks('on_forced_join', name, player_name, channel_name, meta) then
+			return false
+		end
+
+		-- inform user
+		minetest.chat_send_player(player_name, name .. " has set your default channel to "
+			.. channel_name .. ".")
+		-- feedback to mover
+		minetest.chat_send_player(name, "Set default channel of " .. player_name
+			.. " to " .. channel_name .. ".")
+		-- inform moderators, if moderator channel is set
+		if beerchat.moderator_channel_name then
+			beerchat.send_on_channel(beerchat.channels[beerchat.main_channel_name].owner,
+				beerchat.moderator_channel_name,
+				name .. " has set default channel of " .. player_name .. " to "
+				.. channel_name .. ".")
+		end
+		-- inform admin
+		minetest.log("action", "CHAT " .. name .. " moved " .. player_name
+			.. " to channel " .. channel_name)
+	end
+	return true
+end
+
+minetest.register_chatcommand("force2channel", {
+	params = "<Channel Name>, <Player Name>",
+	description = "Force player named <Player Name> to channel named <Channel Name>. Requires ban privilege.",
+	privs = { ban = true },
+	func = beerchat.force_player_to_channel
+})

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -30,10 +30,13 @@ load_plugin("jail", false)
 load_plugin("cleaner", false)
 
 -- Overrides for message handlers provided by other mods
-load_plugin("override", false)
+load_plugin("override", true)
 
 -- Allows colorizing messages on specified channels
 load_plugin("colorize", true)
 
 -- Set server wide announcements
 load_plugin("announce", false)
+
+-- Adds command "/force2channel channel,player"
+load_plugin("force2channel", true)

--- a/plugin/whisper.lua
+++ b/plugin/whisper.lua
@@ -72,3 +72,9 @@ beerchat.whisper = function(name, message)
 end
 
 beerchat.register_on_chat_message(beerchat.whisper)
+
+minetest.register_chatcommand("whis", {
+	params = "<message>",
+	description = "Whisper command for those who can't use $",
+	func = function(name, param) beerchat.whisper(name, "$ " .. param) end
+})

--- a/session.lua
+++ b/session.lua
@@ -21,6 +21,8 @@ minetest.register_on_joinplayer(function(player)
 		beerchat.currentPlayerChannel[name] = beerchat.main_channel_name
 	end
 
+	beerchat.execute_callbacks("after_joinplayer", name, meta)
+
 end)
 
 minetest.register_on_leaveplayer(function(player)

--- a/spec/init_spec.lua
+++ b/spec/init_spec.lua
@@ -46,11 +46,4 @@ describe("Chatting", function()
 		assert.is_nil(beerchat.channels["foo"])
 	end)
 
-	it("whispers", function()
-		pending("Spy is not working correctly here, possibly it cannot track indirect calls")
-		spy.on(beerchat, "whisper")
-		SX:send_chat_message("$ Everyone ignore me, this is just a test")
-		assert.spy(beerchat.whisper).was.called()
-	end)
-
 end)

--- a/spec/plugin_force2channel_spec.lua
+++ b/spec/plugin_force2channel_spec.lua
@@ -1,0 +1,49 @@
+require("mineunit")
+
+mineunit("core")
+mineunit("player")
+mineunit("server")
+
+sourcefile("init")
+
+describe("force2channel command", function()
+
+	local SX = Player("SX", { shout = 1, ban = 1 })
+	local XX = Player("XX", { shout = 1 })
+
+	setup(function()
+		mineunit:execute_on_joinplayer(SX)
+		mineunit:execute_on_joinplayer(XX)
+		SX:send_chat_message("/cc notmain")
+		assert.equals("main", beerchat.get_player_channel("SX"))
+		assert.equals("main", beerchat.get_player_channel("XX"))
+	end)
+
+	teardown(function()
+		mineunit:execute_on_leaveplayer(SX)
+		mineunit:execute_on_leaveplayer(XX)
+	end)
+
+	it("forces player to channel", function()
+		SX:send_chat_message("/force2channel notmain, XX")
+		assert.equals("main", beerchat.get_player_channel("SX"))
+		assert.equals("notmain", beerchat.get_player_channel("XX"))
+		assert.equals("notmain", XX:get_meta():get_string("beerchat:current_channel"))
+	end)
+
+	it("handles invalid channel name", function()
+		SX:send_chat_message("/force2channel doesnotexist, XX")
+		assert.equals("main", beerchat.get_player_channel("SX"))
+		assert.equals("notmain", beerchat.get_player_channel("XX"))
+		assert.equals("notmain", XX:get_meta():get_string("beerchat:current_channel"))
+	end)
+
+	it("handles empty channel name", function()
+		SX:send_chat_message("/force2channel , XX")
+		assert.equals("main", beerchat.get_player_channel("SX"))
+		assert.equals("notmain", beerchat.get_player_channel("XX"))
+		assert.equals("notmain", XX:get_meta():get_string("beerchat:current_channel"))
+	end)
+
+
+end)

--- a/spec/plugin_whisper_spec.lua
+++ b/spec/plugin_whisper_spec.lua
@@ -1,0 +1,27 @@
+require("mineunit")
+
+mineunit("core")
+mineunit("player")
+mineunit("server")
+
+sourcefile("init")
+
+describe("Whisper", function()
+
+	local SX = Player("SX", { shout = 1 })
+
+	setup(function()
+		mineunit:execute_on_joinplayer(SX)
+	end)
+
+	teardown(function()
+		mineunit:execute_on_leaveplayer(SX)
+	end)
+
+	it("whispers", function()
+		spy.on(beerchat, "send_message")
+		SX:send_chat_message("$ Everyone ignore me, this is just a test")
+		assert.spy(beerchat.send_message).was.called()
+	end)
+
+end)


### PR DESCRIPTION
* Added on_joinplayer hook guaranteed to execute after player channel is set, not used but already figured out this should be available for upcoming features.
* Fixed plugin/override.lua loading, accidentally disabled that while I moved a lot of functionality to plugin directory.
* Moved `/whis` command registration to existing `plugin/whisper.lua` (before this command would crash if whisper is disabled).
* Moved `/force2channel` command to new `plugin/force2channel.lua` (loaded by default, behavior does not change).
* Added `*` as special configuration value for `plugin/colorize.lua`, enables color codes for all channels.
* Added few simple smoke tests.