### PR TITLE
Disable notification sounds for channel messages

### DIFF
--- a/common.lua
+++ b/common.lua
@@ -48,7 +48,7 @@ beerchat.send_message = function(name, message, channel)
 	end
 
 	minetest.chat_send_player(name, message)
-	-- TODO: read player settings for channel sounds
+	--[[ TODO: read player settings for channel sounds
 	if beerchat.enable_sounds and channel ~= beerchat.main_channel_name then
 		minetest.sound_play(
 			beerchat.channel_message_sound, {
@@ -57,5 +57,5 @@ beerchat.send_message = function(name, message, channel)
 			},
 			true
 		)
-	end
+	end --]]
 end


### PR DESCRIPTION
Removes sounds for channel messages: #14
Commented out as this is supposed to be enabled / allowed again after player settings are available.