### PR TITLE
Remove unjailed players from jail channel

### DIFF
--- a/chatcommands.lua
+++ b/chatcommands.lua
@@ -359,7 +359,7 @@ local unmute_player = {
 
 		if beerchat.has_player_muted_player(name, param) then
 			minetest.get_player_by_name(name):get_meta():set_string(
-				"beerchat:muted:" .. param, nil)
+				"beerchat:muted:" .. param, "")
 			minetest.chat_send_player(name, "Unmuted player " .. param .. ".")
 		else
 			minetest.chat_send_player(name, "Player " .. param .. " was not muted.")

--- a/common.lua
+++ b/common.lua
@@ -1,4 +1,32 @@
 
+-- Add/join player to channel
+beerchat.add_player_channel = function(name, channel)
+	if not beerchat.playersChannels[name][channel] then
+		local meta = minetest.get_player_by_name(name):get_meta()
+		beerchat.playersChannels[name][channel] = "joined"
+		meta:set_string("beerchat:channels", minetest.write_json(beerchat.playersChannels[name]))
+	end
+end
+
+-- Remove/part player from channel
+beerchat.remove_player_channel = function(name, channel)
+	if beerchat.playersChannels[name][channel] then
+		local meta = minetest.get_player_by_name(name):get_meta()
+		beerchat.playersChannels[name][channel] = nil
+		meta:set_string("beerchat:channels", minetest.write_json(beerchat.playersChannels[name]))
+	end
+end
+
+-- Set active channel of player, join player to channel if not already joined
+beerchat.set_player_channel = function(name, channel)
+	if beerchat.currentPlayerChannel[name] ~= channel then
+		beerchat.add_player_channel(name, channel)
+		local meta = minetest.get_player_by_name(name):get_meta()
+		beerchat.currentPlayerChannel[name] = channel
+		meta:set_string("beerchat:current_channel", channel)
+	end
+end
+
 beerchat.get_player_channel = function(name)
 	if type(name) == "string" then
 		local channel = beerchat.currentPlayerChannel[name]

--- a/common.lua
+++ b/common.lua
@@ -44,8 +44,7 @@ beerchat.fix_player_channel = function(name, notify)
 				beerchat.main_channel_name..". Please resend your message"
 		)
 	end
-	beerchat.currentPlayerChannel[name] = beerchat.main_channel_name
-	minetest.get_player_by_name(name):get_meta():set_string("beerchat:current_channel", beerchat.main_channel_name)
+	beerchat.set_player_channel(name, beerchat.main_channel_name)
 end
 
 beerchat.has_player_muted_player = function(name, other_name)

--- a/plugin/event-logging.lua
+++ b/plugin/event-logging.lua
@@ -1,0 +1,21 @@
+
+beerchat.register_callback('on_forced_join', function(name, target, channel, from_channel)
+	-- does not make sense to log or inform everyone about moves that wont affect anything
+	if channel == from_channel then
+		minetest.chat_send_player(name, "Channel of " .. target .. " was already #" .. channel .. ".")
+		return
+	end
+	-- inform user
+	minetest.chat_send_player(target, name .. " has set your default channel to #" .. channel .. ".")
+	-- feedback to mover
+	minetest.chat_send_player(name, "Set default channel of " .. target .. " to #" .. channel .. ".")
+	-- inform moderators, if moderator channel is set
+	local move_msg = name .. " has set default channel of " .. target
+		.. " from #" .. from_channel .. " to #" .. channel .. "."
+	if beerchat.moderator_channel_name then
+		local sender = beerchat.channels[beerchat.main_channel_name].owner
+		beerchat.send_on_channel(sender, beerchat.moderator_channel_name, move_msg)
+	end
+	-- inform admin
+	minetest.log("action", "CHAT " .. move_msg)
+end)

--- a/plugin/hash.lua
+++ b/plugin/hash.lua
@@ -55,9 +55,7 @@ beerchat.register_on_chat_message(function(name, message)
 					beerchat.currentPlayerChannel[name], channel_name) then
 					return false
 				end
-				beerchat.currentPlayerChannel[name] = channel_name
-				minetest.get_player_by_name(name):get_meta():set_string(
-					"beerchat:current_channel", channel_name)
+				beerchat.set_player_channel(name, channel_name)
 				if channel_name == beerchat.main_channel_name then
 					minetest.chat_send_player(
 						name,

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -40,3 +40,6 @@ load_plugin("announce", false)
 
 -- Adds command "/force2channel channel,player"
 load_plugin("force2channel", true)
+
+-- Adds logging and info messages for certain events
+load_plugin("event-logging", true)

--- a/plugin/jail.lua
+++ b/plugin/jail.lua
@@ -17,22 +17,7 @@ beerchat.channels[beerchat.jail.channel_name] = {
 beerchat.jail.list = {}
 
 beerchat.is_player_jailed = function(name)
-	return true == beerchat.jail.list[name]
-end
-
-beerchat.jail.handle_jail_lock = function(name, meta, jailing)
-	-- going to/from jail?
-	if jailing then
-		meta:set_string("beerchat:jailed", beerchat.get_player_channel(name) or beerchat.main_channel_name)
-		beerchat.jail.list[name] = true
-	elseif beerchat.is_player_jailed(name) then
-		-- remove jail channel from player channels
-		beerchat.remove_player_channel(name, beerchat.jail.channel_name)
-		beerchat.set_player_channel(name, meta:get("beerchat:jailed") or beerchat.main_channel_name)
-		-- remove player from chat jail
-		meta:set_string("beerchat:jailed", "")
-		beerchat.jail.list[name] = nil
-	end
+	return not not beerchat.jail.list[name]
 end
 
 beerchat.jail.chat_jail = function(name, param)
@@ -40,63 +25,85 @@ beerchat.jail.chat_jail = function(name, param)
 		return false, "ERROR: Invalid number of arguments. Please supply the player name(s)."
 	end
 
-	if not beerchat.channels[beerchat.jail.channel_name] then
-		return false, "ERROR: Channel " .. beerchat.jail.channel_name
-			.. " does not exist. Someone deleted it... fix by adding "
-			.. "before_delete_chan event :)"
+	local channel = beerchat.jail.channel_name
+	if not beerchat.channels[channel] then
+		return false, "ERROR: Channel " .. channel
+			.. " does not exist. Someone deleted it... fix by adding before_delete_chan event :)"
 	end
 
 	local player_names = string.gmatch(param, "[^%s,]+")
 	for player_name in player_names do
-		beerchat.force_player_to_channel(name, string.format('%s, %s',
-			beerchat.jail.channel_name, player_name))
+		local player = minetest.get_player_by_name(player_name)
+		if player then
+			if not beerchat.is_player_jailed(player_name) then
+				local from_channel = beerchat.get_player_channel(player_name) or beerchat.main_channel_name
+				-- force join and set default channel
+				beerchat.set_player_channel(player_name, channel)
+				-- handle chat jail lock through on_forced_join callback
+				beerchat.execute_callbacks('on_forced_join', name, player_name, channel, from_channel)
+			else
+				minetest.chat_send_player(name, "WARNING: " .. player_name .. " is already jailed, skipping.")
+			end
+		else
+			minetest.chat_send_player(name, "WARNING: " .. player_name .. " does not exist or is not online.")
+		end
 	end
 	return true
 end
 minetest.register_chatcommand("chat_jail", {
 	params = "<Player Name> [<Player Name> ...]",
-	description = string.format("Move players <Player Name> to jail channel. "
-		.. "You must have %s priv to use this.", beerchat.jail.priv),
+	description = ("Move players <Player Name> to jail channel. Requires %s privilege."):format(beerchat.jail.priv),
 	privs = { [beerchat.jail.priv] = true },
 	func = beerchat.jail.chat_jail
 })
 
 beerchat.jail.chat_unjail = function(name, param)
 	if not param or param == "" then
-		return false, "ERROR: Invalid number of arguments. Please supply the player name(s)."
+		-- List chat jailed online players
+		local names = {}
+		for player_name,_ in pairs(beerchat.jail.list) do
+			table.insert(names, player_name)
+		end
+		if #names > 0 then
+			minetest.chat_send_player(name, "Jailed players currently online: " .. table.concat(names, ", "))
+		else
+			minetest.chat_send_player(name, "No jailed players currently online.")
+		end
+		return true
 	end
 	local player_names = string.gmatch(param, "[^%s,]+")
 	for player_name in player_names do
 		local player = minetest.get_player_by_name(player_name)
-		if not player then
-			return false, "ERROR: " .. player_name .. " does not exist or is not online."
+		if player then
+			if beerchat.is_player_jailed(player_name) then
+				-- Release player from chat jail
+				local from_channel = beerchat.get_player_channel(player_name) or beerchat.main_channel_name
+				local to_channel = player:get_meta():get("beerchat:jailed") or beerchat.main_channel_name
+				if to_channel == beerchat.jail.channel_name then
+					-- Always remove player from jail channel when unjailing
+					to_channel = beerchat.main_channel_name
+				end
+				beerchat.set_player_channel(player_name, to_channel)
+				beerchat.execute_callbacks('on_forced_join', name, player_name, to_channel, from_channel)
+			else
+				minetest.chat_send_player(name, "WARNING: " .. player_name .. " is not jailed, skipping.")
+			end
 		else
-			local meta = player:get_meta()
-			beerchat.jail.handle_jail_lock(player_name, meta, false)
-			-- inform user
-			minetest.chat_send_player(player_name, "You have been released from chat jail.")
-			-- feedback to mover
-			minetest.chat_send_player(name, "Released " .. player_name .. " from chat jail.")
-			-- inform admin
-			minetest.log("action", "CHAT " .. name .. " released " .. player_name
-				.. " from jail channel " .. beerchat.jail.channel_name)
+			minetest.chat_send_player(name, "WARNING: " .. player_name .. " does not exist or is not online.")
 		end
 	end
 	return true
 end
 minetest.register_chatcommand("chat_unjail", {
-	params = "<Player Name> [<Player Name> ...]",
-	description = string.format("Release players <Player Name> from jail. Players *can* "
-		.. "switch channel after this. You must have %s priv to use this.",
-		beerchat.jail.priv),
+	params = "[<Player Name> [<Player Name> ...]]",
+	description = ("Release players <Player Name> from jail. Requires %s privilege."):format(beerchat.jail.priv),
 	privs = { [beerchat.jail.priv] = true },
 	func = beerchat.jail.chat_unjail
 })
 
-minetest.register_on_joinplayer(function(player)
+beerchat.register_callback('after_joinplayer', function(player)
 	local name = player:get_player_name()
 	local meta = player:get_meta()
-
 	local jailed = meta:get("beerchat:jailed")
 
 	-- Remove old 0 value indicating that playes has been jailed before but is not currently jailed
@@ -107,12 +114,8 @@ minetest.register_on_joinplayer(function(player)
 
 	if jailed then
 		beerchat.jail.list[name] = true
-		beerchat.currentPlayerChannel[name] = beerchat.jail.channel_name
-		beerchat.playersChannels[name][beerchat.jail.channel_name] = "joined"
-	else
-		beerchat.jail.list[name] = nil
+		beerchat.set_player_channel(name, beerchat.jail.channel_name)
 	end
-
 end)
 
 minetest.register_on_leaveplayer(function(player)
@@ -187,7 +190,34 @@ beerchat.register_callback('before_check_muted', function(name, muted)
 	end
 end)
 
-beerchat.register_callback('on_forced_join', function(name, target, channel, target_meta)
-	beerchat.jail.handle_jail_lock(target, target_meta,
-		channel == beerchat.jail.channel_name)
+beerchat.register_callback('on_forced_join', function(name, target, channel, from_channel)
+	-- going to/from jail?
+	if channel == beerchat.jail.channel_name then
+		if beerchat.is_player_jailed(target) then
+			minetest.chat_send_player(name, "WARNING: " .. target .. " is already jailed, not jailing again.")
+			return
+		end
+		local player = minetest.get_player_by_name(target)
+		if player then
+			local meta = player:get_meta()
+			-- save previous channel, lock player to jail channel and set jail channel as default
+			meta:set_string("beerchat:jailed", from_channel or beerchat.main_channel_name)
+			beerchat.jail.list[target] = true
+		else
+			minetest.chat_send_player(name, "ERROR: " .. target .. " does not exist or is not online.")
+		end
+	elseif beerchat.is_player_jailed(target) then
+		local player = minetest.get_player_by_name(target)
+		if player then
+			local meta = player:get_meta()
+			-- restore previous channel, remove jail channel from player channels and release player from chat jail
+			beerchat.remove_player_channel(target, beerchat.jail.channel_name)
+			meta:set_string("beerchat:jailed", "")
+			beerchat.jail.list[target] = nil
+			-- inform user
+			minetest.chat_send_player(target, "You have been released from chat jail.")
+			-- feedback to mover
+			minetest.chat_send_player(name, "Released " .. target .. " from chat jail.")
+		end
+	end
 end)

--- a/session.lua
+++ b/session.lua
@@ -21,7 +21,7 @@ minetest.register_on_joinplayer(function(player)
 		beerchat.currentPlayerChannel[name] = beerchat.main_channel_name
 	end
 
-	beerchat.execute_callbacks("after_joinplayer", name, meta)
+	beerchat.execute_callbacks("after_joinplayer", player)
 
 end)
 

--- a/spec/fixtures/minetest.conf
+++ b/spec/fixtures/minetest.conf
@@ -1,0 +1,8 @@
+beerchat.enable_jail = true
+beerchat.jail.channel_name = jailchannel
+
+beerchat.colorize_channels = *
+
+beerchat.enable_cleaner = true
+
+beerchat.enable_announce = true

--- a/spec/plugin_force2channel_spec.lua
+++ b/spec/plugin_force2channel_spec.lua
@@ -45,5 +45,13 @@ describe("force2channel command", function()
 		assert.equals("notmain", XX:get_meta():get_string("beerchat:current_channel"))
 	end)
 
+	it("handles jail channel name", function()
+		local oldchannel = XX:get_meta():get_string("beerchat:current_channel")
+		SX:send_chat_message("/force2channel jailchannel, XX")
+		assert.equals("main", beerchat.get_player_channel("SX"))
+		assert.equals("jailchannel", beerchat.get_player_channel("XX"))
+		assert.equals("jailchannel", XX:get_meta():get_string("beerchat:current_channel"))
+		assert.equals(oldchannel, XX:get_meta():get_string("beerchat:jailed"))
+	end)
 
 end)

--- a/spec/plugin_jail_spec.lua
+++ b/spec/plugin_jail_spec.lua
@@ -1,0 +1,93 @@
+require("mineunit")
+
+mineunit("core")
+mineunit("player")
+mineunit("server")
+
+sourcefile("init")
+
+-- Players, initialized in test environment setup functions
+local SX, XX
+
+local function do_setup()
+	SX = Player("SX", { shout = 1, ban = 1 })
+	mineunit:execute_on_joinplayer(SX)
+	assert.equals("main", beerchat.get_player_channel("SX"))
+end
+
+local function do_teardown()
+	mineunit:execute_on_leaveplayer(SX)
+end
+
+local function do_before_each()
+	XX = Player("XX", { shout = 1 })
+	mineunit:execute_on_joinplayer(XX)
+	assert.equals("main", beerchat.get_player_channel("XX"))
+end
+
+local function do_after_each()
+	mineunit:execute_on_leaveplayer(XX)
+	XX = nil
+end
+
+describe("chat_jail command", function()
+
+	setup(do_setup)
+	teardown(do_teardown)
+	before_each(do_before_each)
+	after_each(do_after_each)
+
+	it("forces player to channel", function()
+		local oldchannel = beerchat.get_player_channel("XX")
+		SX:send_chat_message("/chat_jail XX")
+		assert.equals("main", beerchat.get_player_channel("SX"))
+		assert.equals("jailchannel", beerchat.get_player_channel("XX"))
+		assert.equals("jailchannel", XX:get_meta():get_string("beerchat:current_channel"))
+		assert.equals(oldchannel, XX:get_meta():get_string("beerchat:jailed"))
+	end)
+
+	it("handles players that are already jailed", function()
+		local oldchannel = beerchat.get_player_channel("XX")
+		SX:send_chat_message("/chat_jail XX")
+		SX:send_chat_message("/chat_jail XX")
+		assert.equals("main", beerchat.get_player_channel("SX"))
+		assert.equals("jailchannel", beerchat.get_player_channel("XX"))
+		assert.equals("jailchannel", XX:get_meta():get_string("beerchat:current_channel"))
+		assert.equals(oldchannel, XX:get_meta():get_string("beerchat:jailed"))
+	end)
+
+	it("handles invalid player name", function()
+		SX:send_chat_message("/chat_jail ***")
+	end)
+
+	it("handles empty player name", function()
+		SX:send_chat_message("/chat_jail")
+		assert.equals("main", beerchat.get_player_channel("SX"))
+	end)
+
+end)
+
+describe("chat_unjail command", function()
+
+	setup(do_setup)
+	teardown(do_teardown)
+	before_each(do_before_each)
+	after_each(do_after_each)
+
+	it("handles invalid player name", function()
+		SX:send_chat_message("/chat_unjail ***")
+	end)
+
+	it("handles empty player name", function()
+		SX:send_chat_message("/chat_unjail")
+	end)
+
+	it("handles players that are not jailed", function()
+		local oldchannel = XX:get_meta():get_string("beerchat:current_channel")
+		SX:send_chat_message("/chat_unjail XX")
+		assert.equals("main", beerchat.get_player_channel("SX"))
+		assert.equals("main", beerchat.get_player_channel("XX"))
+		assert.is_nil(XX:get_meta():get("beerchat:jailed"))
+	end)
+
+end)


### PR DESCRIPTION
Closes #40 

Needs some testing. Things added:
* Save current chat channel when jailing players
* Restore previous channel when releasing players
* Remove jail channel from player channels when releasing player

Few weird things caused with channel named 0 known well enough and not worth "fixing".