### PR TITLE
Add some delay before password checks

### DIFF
--- a/plugin/password.lua
+++ b/plugin/password.lua
@@ -7,6 +7,7 @@ end
 
 local only_new_players = minetest.settings:get("beerchat.password.mode") == "new"
 local show_formspec = minetest.settings:get_bool("beerchat.password.use_form", true)
+local initial_delay = tonumber(minetest.settings:get("beerchat.password.delay")) or 60
 local message = minetest.settings:get("beerchat.password.message") or "*** Please change your password"
 local fs_message = minetest.formspec_escape(message)
 
@@ -21,22 +22,19 @@ local function validate_password(name)
 	return true
 end
 
-beerchat.register_callback('after_joinplayer', function(player, last_login)
-	if not only_new_players or last_login == nil then
-		local name = player:get_player_name()
-		if not validate_password(name) then
-			password_notify[name] = minetest.get_us_time()
-			minetest.chat_send_player(name, "\n" .. message)
-			if last_login and show_formspec then
-				-- Formspec notification if player has not changed password during first login
-				minetest.show_formspec(name, "MT_PAUSE_MENU",
-					"formspec_version[3]size[14,3]bgcolor[#66F;both;]button_exit[0.5,0.5;13,1;ok;I will]"
-					.. "style_type[*;textcolor=#F00;font_size=*1.2]label[0.5,2;".. fs_message .."]"
-				)
-			end
+local function handle_player(name, last_login)
+	if minetest.get_player_by_name(name) and not validate_password(name) then
+		password_notify[name] = minetest.get_us_time()
+		minetest.chat_send_player(name, "\n" .. message)
+		if last_login and show_formspec then
+			-- Formspec notification if player has not changed password during first login
+			minetest.show_formspec(name, "MT_PAUSE_MENU",
+				"formspec_version[3]size[14,3]bgcolor[#66F;both;]button_exit[0.5,0.5;13,1;ok;I will]"
+				.. "style_type[*;textcolor=#F00;font_size=*1.2]label[0.5,2;".. fs_message .."]"
+			)
 		end
 	end
-end)
+end
 
 beerchat.register_callback('before_send', function(name)
 	-- Only run checks if account is marked for notifications
@@ -53,6 +51,13 @@ beerchat.register_callback('before_send', function(name)
 		end
 		-- Complain about bad password, this can continue for few seconds after password change
 		minetest.chat_send_player(name, message)
+	end
+end)
+
+beerchat.register_callback('after_joinplayer', function(player, last_login)
+	if not only_new_players or last_login == nil then
+		local name = player:get_player_name()
+		minetest.after(initial_delay, function() handle_player(name, last_login) end)
 	end
 end)
 


### PR DESCRIPTION
Add 1 minute (configurable) delay between player join and initial password check to not start complaining right away after player joined game and also to not replace possible news formspec shown immediately after joining.

This includes ~bug~feature to run initial check multiple times if player manages to join multiple times in this time frame, basically player can get 10 alert forms popups in a row if he managed to part/join 10 times.

Usually players wont part/join like that so not sure if it is worth doing anything for that.
If player is not logged in when timer expires then checks are skipped just like before, so it is just timers running.