### PR TITLE
Cleanup / fix duplicate event hooks

### DIFF
--- a/plugin/hash.lua
+++ b/plugin/hash.lua
@@ -45,8 +45,6 @@ beerchat.register_on_chat_message(function(name, message)
 		)
 	elseif msg == "" then
 		switch_channel(name, channel_name)
-	elseif not beerchat.execute_callbacks('before_send', name, msg, channel_name) then
-		return false
 	elseif not beerchat.is_player_subscribed_to_channel(name, channel_name) then
 		minetest.chat_send_player(name, "You need to join this channel in order to be able to send messages to it")
 	else

--- a/plugin/me.lua
+++ b/plugin/me.lua
@@ -1,12 +1,17 @@
 
 local me_message_string = "|#${channel_name}| * ${from_player} ${message}"
 
-local me_override = {
+minetest.register_chatcommand("me", {
 	params = "<Message>",
 	description = "Send message in the \"* player message\" format, e.g. /me eats pizza becomes |#"..
 		beerchat.main_channel_name.."| * Player01 eats pizza",
 	func = function(name, param)
-		local msg = param
+		local msg_data = beerchat.default_on_receive(name, param)
+		if not msg_data then
+			return true
+		end
+		local msg = msg_data.message
+		name = msg_data.name
 		local channel = beerchat.get_player_channel(name)
 		if not channel then
 			beerchat.fix_player_channel(name, true)
@@ -42,6 +47,4 @@ local me_override = {
 		end
 		return true
 	end
-}
-
-minetest.register_chatcommand("me", me_override)
+})

--- a/plugin/pm.lua
+++ b/plugin/pm.lua
@@ -17,13 +17,6 @@ end)
 beerchat.register_on_chat_message(function(name, message)
 	minetest.log("action", "CHAT " .. name .. ": " .. message)
 
-	local msg_data = {name=name,message=message}
-	if beerchat.execute_callbacks('on_receive', msg_data) then
-		message = msg_data.message
-	else
-		return false
-	end
-
 	local players, msg = string.match(message, "^@([^%s:]*)[%s:](.*)")
 	if players and msg then
 		if msg == "" then
@@ -170,6 +163,13 @@ local msg_override = {
 				"for compatibility with the old chat command but with new style chat muting support "..
 				  "(players will not receive your message if they muted you) and multiple (comma separated) player support",
 	func = function(name, param)
+		local msg_data = beerchat.default_on_receive(name, param)
+		if not msg_data then
+			return true
+		end
+		name = msg_data.name
+		param = msg_data.message
+
 		minetest.log("action", "PM " .. name .. ": " .. param)
 		local players, msg = string.match(param, "^(.-) (.*)")
 		if players and msg then

--- a/plugin/whisper.lua
+++ b/plugin/whisper.lua
@@ -93,5 +93,11 @@ beerchat.register_on_chat_message(beerchat.whisper)
 minetest.register_chatcommand("whis", {
 	params = "<message>",
 	description = "Whisper command for those who can't use $",
-	func = function(name, param) beerchat.whisper(name, "$ " .. param) end
+	func = function(name, param)
+		local msg = beerchat.default_on_receive(name, param)
+		if msg then
+			beerchat.whisper(msg.name, "$ " .. msg.message)
+		end
+		return true
+	end
 })

--- a/spec/hooks_spec.lua
+++ b/spec/hooks_spec.lua
@@ -1,0 +1,105 @@
+require("mineunit")
+
+mineunit("core")
+mineunit("player")
+mineunit("server")
+
+sourcefile("init")
+
+describe("Hooks", function()
+
+	local SX = Player("SX", { shout = 1 })
+
+	-- Use custom event handler to count on_receive calls
+	local assert_msg = '%s called %d times, expected %d times. Message: "%s"'
+	local call_count = {}
+	local function test(event, message, count)
+		if not call_count[event] then
+			call_count[event] = 0
+			beerchat.register_callback(event, function()
+				call_count[event] = call_count[event] + 1
+			end)
+        end
+		SX:send_chat_message(message)
+		local temp_count = call_count[event]
+		call_count[event] = 0
+		assert(temp_count == count, assert_msg:format(event, temp_count, count, message))
+	end
+
+	setup(function()
+		mineunit:execute_on_joinplayer(SX)
+	end)
+
+	teardown(function()
+		mineunit:execute_on_leaveplayer(SX)
+	end)
+
+	describe("on_receive", function()
+
+		local method = "on_receive"
+
+		it("executed once for default message", function()
+			test(method, "always executed once test", 1)
+		end)
+
+		it("executed once for # message", function()
+			test(method, "#main always executed once test", 1)
+		end)
+
+		it("executed once for $ message", function()
+			test(method, "$ always executed once test", 1)
+		end)
+
+		it("executed once for @ message", function()
+			test(method, "@SX always executed once test", 1)
+		end)
+
+		it("executed once for /msg message", function()
+			test(method, "/msg SX always executed once test", 1)
+		end)
+
+		it("executed once for /me message", function()
+			test(method, "/me always executed once test", 1)
+		end)
+
+		it("executed once for /whis message", function()
+			test(method, "/whis always executed once test", 1)
+		end)
+
+	end)
+
+	describe("before_send", function()
+
+		local method = "before_send"
+
+		it("executed once for default message", function()
+			test(method, "always executed once test", 1)
+		end)
+
+		it("executed once for # message", function()
+			test(method, "#main always executed once test", 1)
+		end)
+
+		it("executed once for $ message", function()
+			test(method, "$ always executed once test", 1)
+		end)
+
+		it("executed once for /me message", function()
+			test(method, "/me always executed once test", 1)
+		end)
+
+		it("executed once for /whis message", function()
+			test(method, "/whis always executed once test", 1)
+		end)
+
+		it("never executed for @ messages", function()
+			test(method, "@SX never executed test", 0)
+		end)
+
+		it("never executed for /msg messages", function()
+			test(method, "/msg SX never executed test", 0)
+		end)
+
+	end)
+
+end)


### PR DESCRIPTION
Added some tests for on_receive and before_send, just counting how many times callbacks will be executed for different messages sent by player.

It is expected that tests are failing and as next step actual code should be changed in a way that tests will pass.

#### DoD:
* Callback events are triggered only once / message sent.
* Callback events are called no matter how message is sent (for example `@SX Hello` vs `/msg SX Hello`).