### PR TITLE
fix permission check to not use "live" player

### DIFF
--- a/plugin/announce.lua
+++ b/plugin/announce.lua
@@ -144,7 +144,7 @@ minetest.register_chatcommand("server-announce", {
 	description = "List and manage server wide messages. Supports \\n, \\t and \\e escape sequences.",
 	func = function(name, param)
 		if param and param ~= "" then
-			if minetest.check_player_privs(minetest.get_player_by_name(name), { ban = 1 }) then
+			if minetest.check_player_privs(name, { ban = true }) then
 				manage_announcements(name, param)
 			else
 				minetest.chat_send_player(name, "Required privileges for arguments: ban")


### PR DESCRIPTION
Context:

```
13:02 <pandorabot> <OgelGames@Discord> can't set server announcements from pandorabot :/
13:02 <pandorabot> <OgelGames@Discord> because of the way the priv check is done https://github.com/minetest-beerchat/beerchat/blob/e056c1a657e6678412d801ce8b4b907ad73c6f84/plugin/announce.lua#L147
```

@OgelGames ^