### PR TITLE
add current channel info to /mc output

### DIFF
--- a/chatcommands.lua
+++ b/chatcommands.lua
@@ -130,7 +130,9 @@ local my_channels = {
 				minetest.sound_play(beerchat.channel_management_sound,
 					{ to_player = name, gain = beerchat.sounds_default_gain })
 			end
-			minetest.chat_send_player(name, dump2(beerchat.playersChannels[name]))
+			minetest.chat_send_player(name, dump2(beerchat.playersChannels[name])
+				.. '\nYour current default channel is: '
+				.. beerchat.currentPlayerChannel[name])
 		else
 			if beerchat.playersChannels[name][param] then
 				if beerchat.enable_sounds then


### PR DESCRIPTION
Currently there is no silent way to check on which channel one is.
This patches current channel info to end of /my_channels output.

Fixes https://github.com/pandorabox-io/in-game/issues/239

(I do not like the idea of making prompt longer, some channel names are quite lengthy)