### PR TITLE
allow force2channel with multiple names

### DIFF
--- a/plugin/force2channel.lua
+++ b/plugin/force2channel.lua
@@ -6,38 +6,45 @@
 beerchat.force_player_to_channel = function(name, param)
 	if not param or param == "" then
 		return false, "ERROR: Invalid number of arguments. Please supply the "
-			.. "channel name and the player name."
+			.. "channel name and the player name(s)."
 	end
 
-	local channel_name, player_name = string.match(param, "(.*), ?(.*)")
+	local channel_name, player_names = string.match(param, "^([^,]+),%s?(.*)$")
 
 	if not channel_name or channel_name == "" then
 		return false, "ERROR: Channel name is empty."
 	end
 
-	if not player_name or player_name == "" then
-		return false, "ERROR: Player name not supplied or empty."
+	if not player_names or player_names == "" then
+		return false, "ERROR: Player name(s) not supplied or empty."
 	end
 
 	if not beerchat.channels[channel_name] then
 		return false, "ERROR: Channel " .. channel_name .. " does not exist."
 	end
 
-	if not minetest.get_player_by_name(player_name) then
-		return false, "ERROR: " .. player_name .. " does not exist or is not online."
-	else
-		local from_channel = beerchat.get_player_channel(player_name) or beerchat.main_channel_name
-		-- force join and set default channel
-		beerchat.set_player_channel(player_name, channel_name)
-		-- execute callbacks after action
-		beerchat.execute_callbacks('on_forced_join', name, player_name, channel_name, from_channel)
+	local errors = {}
+	for player_name in string.gmatch(player_names, '[^%s,]+') do
+		if not minetest.get_player_by_name(player_name) then
+			table.insert(errors, 'ERROR: "' .. player_name .. '" does not exist or is not online.')
+		else
+			local from_channel = beerchat.get_player_channel(player_name) or beerchat.main_channel_name
+			-- force join and set default channel
+			beerchat.set_player_channel(player_name, channel_name)
+			-- execute callbacks after action
+			beerchat.execute_callbacks('on_forced_join', name, player_name, channel_name, from_channel)
+		end
 	end
-	return true
+	if 0 == #errors then return true end
+	return false, table.concat(errors, '\n')
 end
 
+local ban_priv = beerchat.jail and beerchat.jail.priv or 'ban'
 minetest.register_chatcommand("force2channel", {
-	params = "<Channel Name>, <Player Name>",
-	description = "Force player named <Player Name> to channel named <Channel Name>. Requires ban privilege.",
-	privs = { ban = true },
+	params = "<Channel Name>,<Player Name>[,<Player2 Name>,...]",
+	description = ("Force player named <Player Name> to channel named <Channel Name>. "
+		.. "Requires %s privilege."):format(ban_priv),
+	privs = { [ban_priv] = true },
 	func = beerchat.force_player_to_channel
 })
+


### PR DESCRIPTION
Better argument parsing, now allows coma separation or space
separation for names. (Also both.)

Comma after channel name is obligatory as channel names
could contain spaces.

Also uses beerchat.jail.priv if available