### PR TITLE
help turn off password check

### DIFF
--- a/plugin/password.lua
+++ b/plugin/password.lua
@@ -1,6 +1,6 @@
 
 local default_password = minetest.settings:get("default_password")
-if not default_password then
+if not default_password or '' == default_password then
 	-- Do not use if default password is not set
 	return
 end


### PR DESCRIPTION
On singleplayer and test servers it has been hard to turn off password reminder.
Something is setting default_password to '' even if minetest.conf does not contain that setting.