### PR TITLE
Cleanup hash.lua

### DIFF
--- a/chatcommands.lua
+++ b/chatcommands.lua
@@ -32,7 +32,7 @@ local create_channel = {
 				.. "maximum of 3 allowed: <Channel Name>,<Password>,<Color>"
 		end
 
-		local lchannel_name = string.trim(str[1] or "")
+		local lchannel_name = string.trim(str[1] or ""):gsub("%s", "-")
 		if lchannel_name == "" then
 			return false, "ERROR: You must supply a channel name"
 		end

--- a/plugin/hash.lua
+++ b/plugin/hash.lua
@@ -1,26 +1,22 @@
 
 -- # chat a.k.a. hash chat/ channel chat code, to send messages in chat channels using #
--- e.g. #my channel: hello everyone in my channel!
+-- e.g. #my-channel: hello everyone in my channel!
 
 local function switch_channel(name, channel)
-	if not beerchat.channels[channel] then
-		minetest.chat_send_player(name, "Channel " .. channel .. " does not exist")
-	elseif not beerchat.is_player_subscribed_to_channel(name, channel) then
+	if not beerchat.is_player_subscribed_to_channel(name, channel) then
 		minetest.chat_send_player(name, "You need to join this channel in order to be able to switch to it")
 	else
 		if not beerchat.execute_callbacks('before_switch_chan', name,
 			beerchat.currentPlayerChannel[name], channel) then
-			return false
+			return
 		end
 		beerchat.set_player_channel(name, channel)
 		if channel == beerchat.main_channel_name then
-			minetest.chat_send_player(
-				name,
+			minetest.chat_send_player(name,
 				"Switched to channel " .. channel .. ", messages will now be sent to this channel"
 			)
 		else
-			minetest.chat_send_player(
-				name,
+			minetest.chat_send_player(name,
 				"Switched to channel " .. channel .. ", messages will now be sent to this channel. "
 				.. "To switch back to the main channel, type #" .. beerchat.main_channel_name
 			)
@@ -42,26 +38,21 @@ beerchat.register_on_chat_message(function(name, message)
 
 	if not channel_name then
 		return false
-	elseif msg == "" then
-		switch_channel(name, channel_name)
-		return true
-	end
-
-	if not beerchat.execute_callbacks('before_send', name, msg, channel_name) then
-		return false
-	end
-
-	if not beerchat.channels[channel_name] then
+	elseif not beerchat.channels[channel_name] then
 		minetest.chat_send_player(name,
 			"Channel " .. channel_name .. " does not exist. Make sure the channel still exists "
-			.. "and you format its name properly, e.g. #channel message or #my channel: message"
+			.. "and you format its name properly, e.g. #channel message"
 		)
+	elseif msg == "" then
+		switch_channel(name, channel_name)
+	elseif not beerchat.execute_callbacks('before_send', name, msg, channel_name) then
+		return false
 	elseif not beerchat.is_player_subscribed_to_channel(name, channel_name) then
 		minetest.chat_send_player(name, "You need to join this channel in order to be able to send messages to it")
 	else
 		beerchat.on_channel_message(channel_name, name, msg)
 		beerchat.send_on_channel(name, channel_name, msg)
 	end
-	return true
 
+	return true
 end)

--- a/plugin/hash.lua
+++ b/plugin/hash.lua
@@ -22,7 +22,7 @@ local function switch_channel(name, channel)
 			minetest.chat_send_player(
 				name,
 				"Switched to channel " .. channel .. ", messages will now be sent to this channel. "
-				"To switch back to the main channel, type #" .. beerchat.main_channel_name
+				.. "To switch back to the main channel, type #" .. beerchat.main_channel_name
 			)
 		end
 		if beerchat.enable_sounds then

--- a/plugin/hash.lua
+++ b/plugin/hash.lua
@@ -1,17 +1,9 @@
 
 -- # chat a.k.a. hash chat/ channel chat code, to send messages in chat channels using #
 -- e.g. #my channel: hello everyone in my channel!
-local hashchat_lastrecv = {}
 
 beerchat.register_on_chat_message(function(name, message)
-
-	local channel_name, msg = string.match(message, "^#(.-): (.*)")
-	if not beerchat.channels[channel_name] then
-		channel_name, msg = string.match(message, "^#(.-) (.*)")
-	end
-	if channel_name == "" then
-		channel_name = hashchat_lastrecv[name]
-	end
+	local channel_name, msg = string.match(message, "^#(%S+) (.*)")
 
 	if channel_name and msg then
 		if not beerchat.execute_callbacks('before_send', name, msg, channel_name) then
@@ -29,10 +21,6 @@ beerchat.register_on_chat_message(function(name, message)
 			minetest.chat_send_player(name, "You need to join this channel in order to "
 				.. "be able to send messages to it")
 		else
-			if channel_name == "" then--use last used channel
-				-- We need to get the target
-				channel_name = hashchat_lastrecv[name]
-			end
 			if channel_name and channel_name ~= "" then
 				beerchat.on_channel_message(channel_name, name, msg)
 				beerchat.send_on_channel(name, channel_name, msg)

--- a/plugin/hash.lua
+++ b/plugin/hash.lua
@@ -2,70 +2,66 @@
 -- # chat a.k.a. hash chat/ channel chat code, to send messages in chat channels using #
 -- e.g. #my channel: hello everyone in my channel!
 
-beerchat.register_on_chat_message(function(name, message)
-	local channel_name, msg = string.match(message, "^#(%S+) (.*)")
-
-	if channel_name and msg then
-		if not beerchat.execute_callbacks('before_send', name, msg, channel_name) then
+local function switch_channel(name, channel)
+	if not beerchat.channels[channel] then
+		minetest.chat_send_player(name, "Channel " .. channel .. " does not exist")
+	elseif not beerchat.is_player_subscribed_to_channel(name, channel) then
+		minetest.chat_send_player(name, "You need to join this channel in order to be able to switch to it")
+	else
+		if not beerchat.execute_callbacks('before_switch_chan', name,
+			beerchat.currentPlayerChannel[name], channel) then
 			return false
 		end
-		if not beerchat.channels[channel_name] then
-			minetest.chat_send_player(name, "Channel " .. channel_name
-				.. " does not exist. Make sure the channel still "
-				.. "exists and you format its name properly, e.g. #channel message "
-				.. "or #my channel: message")
-		elseif msg == "" then
-			minetest.chat_send_player(name, "Please enter the message you would like to "
-				.. "send to the channel")
-		elseif not beerchat.is_player_subscribed_to_channel(name, channel_name) then
-			minetest.chat_send_player(name, "You need to join this channel in order to "
-				.. "be able to send messages to it")
+		beerchat.set_player_channel(name, channel)
+		if channel == beerchat.main_channel_name then
+			minetest.chat_send_player(
+				name,
+				"Switched to channel " .. channel .. ", messages will now be sent to this channel"
+			)
 		else
-			if channel_name and channel_name ~= "" then
-				beerchat.on_channel_message(channel_name, name, msg)
-				beerchat.send_on_channel(name, channel_name, msg)
-			else
-				return false
-			end
+			minetest.chat_send_player(
+				name,
+				"Switched to channel " .. channel .. ", messages will now be sent to this channel. "
+				"To switch back to the main channel, type #" .. beerchat.main_channel_name
+			)
 		end
-		return true
-	else
-		channel_name = string.match(message, "^#(.*)")
-		if channel_name then
-			if not beerchat.channels[channel_name] then
-				minetest.chat_send_player(name, "Channel " .. channel_name
-					.. " does not exist")
-			elseif not beerchat.is_player_subscribed_to_channel(name, channel_name) then
-				minetest.chat_send_player(name, "You need to join this channel in order "
-					.. "to be able to switch to it")
-			else
-				if not beerchat.execute_callbacks('before_switch_chan', name,
-					beerchat.currentPlayerChannel[name], channel_name) then
-					return false
-				end
-				beerchat.set_player_channel(name, channel_name)
-				if channel_name == beerchat.main_channel_name then
-					minetest.chat_send_player(
-						name,
-						"Switched to channel " .. channel_name
-						.. ", messages will now be sent to this channel"
-					)
-				else
-					minetest.chat_send_player(
-						name,
-						"Switched to channel " .. channel_name
-						.. ", messages will now be sent to this channel. To switch back "
-						.. "to the main channel, type #" .. beerchat.main_channel_name
-					)
-				end
+		if beerchat.enable_sounds then
+			minetest.sound_play(
+				beerchat.channel_management_sound,
+				{
+					to_player = name,
+					gain = beerchat.sounds_default_gain
+				}
+			)
+		end
+	end
+end
 
-				if beerchat.enable_sounds then
-					minetest.sound_play(beerchat.channel_management_sound, {
-						to_player = name, gain = beerchat.sounds_default_gain })
-				end
-			end
-			return true
-		end
+beerchat.register_on_chat_message(function(name, message)
+	local channel_name, msg = string.match(message, "^#(%S+) ?(.*)")
+
+	if not channel_name then
+		return false
+	elseif msg == "" then
+		switch_channel(name, channel_name)
+		return true
+	end
+
+	if not beerchat.execute_callbacks('before_send', name, msg, channel_name) then
 		return false
 	end
+
+	if not beerchat.channels[channel_name] then
+		minetest.chat_send_player(name,
+			"Channel " .. channel_name .. " does not exist. Make sure the channel still exists "
+			.. "and you format its name properly, e.g. #channel message or #my channel: message"
+		)
+	elseif not beerchat.is_player_subscribed_to_channel(name, channel_name) then
+		minetest.chat_send_player(name, "You need to join this channel in order to be able to send messages to it")
+	else
+		beerchat.on_channel_message(channel_name, name, msg)
+		beerchat.send_on_channel(name, channel_name, msg)
+	end
+	return true
+
 end)


### PR DESCRIPTION
Hash channel handler contains a lot of unused stuff that is not really needed.
Cleanup a bit.

Also removes `#channel: message` format, this might affect current channels where channel name contains white space.
Space in channel could be converted to dash or underscore. However I think it would be better to just forget about those channels as those are not very common, some commands wont work with them and players can recreate channels anyway.