### PR TITLE
Добавлен плагин priv_cc

### DIFF
--- a/chatcommands.lua
+++ b/chatcommands.lua
@@ -24,10 +24,12 @@ local create_channel = {
 		--check player privileges if plugin priv_cc is enabled
 		local name_priv2cc = minetest.settings:get("beerchat.name_priv_cc")
 		if minetest.settings:get_bool("beerchat.enable_priv_cc") then
-        		if not (minetest.check_player_privs(lowner, name_priv2cc) or minetest.check_player_privs(lowner, beerchat.admin_priv)) then
-                		return false, "You don't have that privilege."
-        		end
-		end  --end check priv_cc
+			if not (minetest.check_player_privs(lowner, name_priv2cc) or
+				 minetest.check_player_privs(lowner, beerchat.admin_priv)) then
+				return false, "You don't have that privilege."
+			end
+		end
+		--end check priv_cc
 
 		if not param or param == "" then
 			return false, "ERROR: Invalid number of arguments. Please supply the channel name as a minimum."

--- a/chatcommands.lua
+++ b/chatcommands.lua
@@ -21,6 +21,14 @@ local create_channel = {
 	func = function(lname, param)
 		local lowner = lname
 
+		--check player privileges if plugin priv_cc is enabled
+		local name_priv2cc = minetest.settings:get("beerchat.name_priv_cc")
+		if minetest.settings:get_bool("beerchat.enable_priv_cc") then
+        		if not (minetest.check_player_privs(lowner, name_priv2cc) or minetest.check_player_privs(lowner, beerchat.admin_priv)) then
+                		return false, "You don't have that privilege."
+        		end
+		end  --end check priv_cc
+
 		if not param or param == "" then
 			return false, "ERROR: Invalid number of arguments. Please supply the channel name as a minimum."
 		end

--- a/chatcommands.lua
+++ b/chatcommands.lua
@@ -22,8 +22,8 @@ local create_channel = {
 		local lowner = lname
 
 		--check player privileges if plugin priv_cc is enabled
-		local name_priv2cc = minetest.settings:get("beerchat.name_priv_cc")
 		if minetest.settings:get_bool("beerchat.enable_priv_cc") then
+			local name_priv2cc = minetest.settings:get("beerchat.priv_cc.name")
 			if not (minetest.check_player_privs(lowner, name_priv2cc) or
 				 minetest.check_player_privs(lowner, beerchat.admin_priv)) then
 				return false, "You don't have that privilege."

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -58,3 +58,6 @@ load_plugin("event-logging", true)
 
 -- Allows linking channels through channel aliases
 load_plugin("alias", false)
+
+-- Add special priv to use create_channel command
+load_plugin("priv_cc", false)

--- a/plugin/priv_cc.lua
+++ b/plugin/priv_cc.lua
@@ -1,6 +1,6 @@
--- if you need to set a special name for privilege, use "beerchat.name_priv_cc = spec_name" in minetest.conf 
+-- if you need to set a special name for privilege, use "beerchat.name_priv_cc = spec_name" in minetest.conf
 local name_priv2cc = minetest.settings:get("beerchat.name_priv_cc")
-if name_priv2cc == '' then name_priv2cc = chat_creator end
+if name_priv2cc == '' then name_priv2cc = 'chat_creator' end
 minetest.log("info", "to create channel add new priv: " .. name_priv2cc)
 local S = minetest.get_translator("name_priv2cc")
         minetest.register_privilege(name_priv2cc, {

--- a/plugin/priv_cc.lua
+++ b/plugin/priv_cc.lua
@@ -1,5 +1,5 @@
 -- if you need to set a special name for privilege, use "beerchat.name_priv_cc = spec_name" in minetest.conf
-local name_priv2cc = minetest.settings:get("beerchat.name_priv_cc")
+local name_priv2cc = minetest.settings:get("beerchat.priv_cc.name")
 if name_priv2cc == '' then name_priv2cc = 'chat_creator' end
 minetest.log("info", "to create channel add new priv: " .. name_priv2cc)
 local S = minetest.get_translator("name_priv2cc")

--- a/plugin/priv_cc.lua
+++ b/plugin/priv_cc.lua
@@ -1,0 +1,9 @@
+-- if you need to set a special name for privilege, use "beerchat.name_priv_cc = spec_name" in minetest.conf 
+local name_priv2cc = minetest.settings:get("beerchat.name_priv_cc")
+if name_priv2cc == '' then name_priv2cc = chat_creator end
+minetest.log("info", "to create channel add new priv: " .. name_priv2cc)
+local S = minetest.get_translator("name_priv2cc")
+        minetest.register_privilege(name_priv2cc, {
+                description = S("Allows you to create a channel"),
+                give_to_singleplayer = false
+        })

--- a/plugin/priv_cc.lua
+++ b/plugin/priv_cc.lua
@@ -2,8 +2,7 @@
 local name_priv2cc = minetest.settings:get("beerchat.priv_cc.name")
 if name_priv2cc == '' then name_priv2cc = 'chat_creator' end
 minetest.log("info", "to create channel add new priv: " .. name_priv2cc)
-local S = minetest.get_translator("name_priv2cc")
-        minetest.register_privilege(name_priv2cc, {
-                description = S("Allows you to create a channel"),
-                give_to_singleplayer = false
-        })
+minetest.register_privilege(name_priv2cc, {
+        description = "Allows you to create a channel (mod beerchat)",
+        give_to_singleplayer = false
+})


### PR DESCRIPTION
Added priv_cc plugin
The plugin creates a new privilege that allows players to create a new channel (cc/create_channel) Users without this privilege cannot create a channel. The plugin is enabled/disabled via minetest.conf beerchat.enable_priv_cc = true/false
The privilege name can be set in minetest.conf (by default it is created with the name chat_creator without specifying it in the config) beer chat.name_priv_cc = chat_creator
